### PR TITLE
Update README example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,23 @@ name: Composer Rich Diff
 
 on:
   pull_request:
+    paths:
+      - '.github/workflows/composer-diff.yml'
+      - 'composer.json'
+      - 'composer.lock'
 
 permissions:
-    contents: read
-    pull-requests: write
+  contents: read
+  pull-requests: write
 
 jobs:
   diff:
     name: Generate Diff
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cs278/composer-rich-diff-action@v1
         with:
-          path: ./composer.json
+          path: composer.json
 ```


### PR DESCRIPTION
The old example usage:

- Doesn't actually function, errored when I tried it
- Uses a mix of indentation
- Has no timeout specified, so can eat up too many CI minutes if there is an issue
- Uses an outdated `actions/checkout`