### PR TITLE
Upgrade to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     default: 'composer.json'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 20 is recommended by GitHub Actions as the LTS to use currently.